### PR TITLE
fix the zoom error issue

### DIFF
--- a/src/components/map/deckgl/deckLayerManager.jsx
+++ b/src/components/map/deckgl/deckLayerManager.jsx
@@ -12,18 +12,7 @@ const ZOOM_LEVEL_MARGIN = 5;
 
 const AREA_THRESHOLD = 1200; //in square miles
 
-const flyToBbox = (bbox) => {
-  if (!bbox || !map) return;
-  const fitbox = [
-    [bbox[0], bbox[1]],
-    [bbox[2], bbox[3]],
-  ];
-  map.fitBounds(fitbox, {
-    offset: [60, 20], //offset in pixels to compensate for the dialog in the top left corner
-    padding: 20, // Add 20 pixels of padding around the bounding box
-    duration: 2000, // Animate the transition over 2 seconds
-  });
-};
+
 
 function filterCountriesByArea(data, threshold, op = 'gt') {
   if (!data) if (!data.length) return {};
@@ -71,25 +60,37 @@ export function DeckLayers({
         setShowCircle(true);
         handleZoomOutEvent(zoom);
       }
-      setZoomLevel(zoom)
+      setZoomLevel(zoom);
     };
 
     map.on('zoomend', handleViewportChange);
     map.on('dragend', handleViewportChange);
-    // map.on('moveend', handleViewportChange);
 
     return () => {
       map.off('zoomend', handleViewportChange);
       map.off('dragend', handleViewportChange);
-      // map.on('moveend', handleViewportChange);
     };
   }, [map]);
 
+  const flyToBbox = (bbox) => {
+    if (!bbox || !map) return;
+    const fitbox = [
+      [bbox[0], bbox[1]],
+      [bbox[2], bbox[3]],
+    ];
+    map.fitBounds(fitbox, {
+      offset: [60, 20], //offset in pixels to compensate for the dialog in the top left corner
+      padding: 20, // Add 20 pixels of padding around the bounding box
+      duration: 2000, // Animate the transition over 2 seconds
+    });
+  };
+
   const handleOnClick = useCallback((bbox) => {
+    setZoomLocation([]); // Clear locked location to prevent MapZoom from snapping back
     setShowCircle(false);
     setShowBoundaries(false);
     flyToBbox(bbox);
-  }, []);
+  }, [map, setZoomLocation]);
 
   const handleOnHover = (name) => {
     const countryName = countryMapping[name]


### PR DESCRIPTION
Fixes:
Problem: The map view was resetting to a default or incorrect position immediately after clicking a country. This happened because the MapZoom component was inadvertently re-triggering its useEffect hook, overriding the imperative 
flyToBbox animation with its own state-based position logic.

Fix: Updated handleOnClick in DeckLayers to explicitly clear the zoomLocation state (setZoomLocation([])) before initiating the fly-to animation. This ensures the MapZoom component returns early and does not interfere with the map's transition to the selected country's bounding box.